### PR TITLE
Fix broken link to v3.2 on welcome page.

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -19,6 +19,6 @@ The guides for earlier releases:
 <a href="http://guides.rubyonrails.org/v4.2/">Rails 4.2</a>,
 <a href="http://guides.rubyonrails.org/v4.1/">Rails 4.1</a>,
 <a href="http://guides.rubyonrails.org/v4.0/">Rails 4.0</a>,
-<a href="http://guides.rubyonrails.org/v3.2/">Rails 3.2</a>, and
+<a href="http://guides.rubyonrails.org/v3.2.22/">Rails 3.2.22</a>, and
 <a href="http://guides.rubyonrails.org/v2.3/">Rails 2.3</a>.
 </p>


### PR DESCRIPTION
### Summary

Link to v3.2 Rails Guides is broken on current edge, and on the current http://guides.rubyonrails.org (4.2.6)

Fixed the link with v3.2.22, which does exist.
### Other Information

It's possible that the preferred fix would be to restore the content that used to be linked at `http://guides.rubyonrails.org/v3.2/`, or to make that link redirect to the most recent version at the 3.2 level; however, this was the expedient fix that I felt I could contribute.
